### PR TITLE
bug/SM-5458: Set inspection_category property as optional in response models, as it isn't defined if the inspection_type is section_81.

### DIFF
--- a/dist/interfaces/inspectionReportingResponse.d.ts
+++ b/dist/interfaces/inspectionReportingResponse.d.ts
@@ -13,7 +13,7 @@ export interface InspectionSummaryResponse {
     area: string;
     inspection_reference_number?: string;
     inspection_type: InspectionType;
-    inspection_category: InspectionCategory;
+    inspection_category?: InspectionCategory;
     inspection_outcome?: InspectionOutcome;
     reinspection_date_time?: Date;
     highway_authority: string;

--- a/src/interfaces/inspectionReportingResponse.ts
+++ b/src/interfaces/inspectionReportingResponse.ts
@@ -15,7 +15,7 @@ export interface InspectionSummaryResponse {
   area: string
   inspection_reference_number?: string
   inspection_type: InspectionType
-  inspection_category: InspectionCategory
+  inspection_category?: InspectionCategory
   inspection_outcome?: InspectionOutcome
   reinspection_date_time?: Date
   highway_authority: string


### PR DESCRIPTION
## Description

Set `inspection_category` property as optional in response models, as it isn't defined if the `inspection_type` is `section_81`.

Relates to https://github.com/departmentfortransport/street-manager-reporting-api/pull/290.

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [x] Branch named {feature|hotfix|task}/{SM-.*}
- [x] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [x] API definitions updated
- [x] Commit messages are meaningful
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
