### PR TITLE
feature/SM-5992: add author organisation ref to comment response

### DIFF
--- a/dist/interfaces/commentReportingResponse.d.ts
+++ b/dist/interfaces/commentReportingResponse.d.ts
@@ -7,6 +7,7 @@ export interface CommentSummaryResponse {
     work_reference_number: string;
     topic: CommentTopic;
     author_email_address: string;
+    author_organisation_reference: string;
     detail: string;
     date_created: Date;
     comment_reference_number: string;

--- a/src/interfaces/commentReportingResponse.ts
+++ b/src/interfaces/commentReportingResponse.ts
@@ -9,6 +9,7 @@ export interface CommentSummaryResponse {
   work_reference_number: string
   topic: CommentTopic
   author_email_address: string
+  author_organisation_reference: string
   detail: string
   date_created: Date
   comment_reference_number: string


### PR DESCRIPTION
## Description

add author organisation ref to comment response

frontend: https://github.com/departmentfortransport/street-manager-frontend/pull/1562
work api: https://github.com/departmentfortransport/street-manager-api/pull/894
reporting client: https://github.com/departmentfortransport/street-manager-reporting-client/pull/122
reporting api: https://github.com/departmentfortransport/street-manager-reporting-api/pull/334

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
