### PR TITLE
feature/SM-6283: add upcoming enum to enums on response models

### DIFF
--- a/dist/interfaces/alterationReportingResponse.d.ts
+++ b/dist/interfaces/alterationReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { AlterationStatus, WorkCategory, WorkStatus, AlterationType, LaneRentalAssessmentOutcome } from './referenceTypes';
+import { AlterationStatusResponse, AlterationTypeResponse, LaneRentalAssessmentOutcomeResponse, WorkCategoryResponse, WorkStatusResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface AlterationReportingResponse extends ReportingResponse {
     rows: AlterationSummaryResponse[];
@@ -13,22 +13,22 @@ export interface AlterationSummaryResponse {
     location_description: string;
     highway_authority: string;
     promoter: string;
-    work_status: WorkStatus;
+    work_status: WorkStatusResponse;
     work_status_string: string;
     proposed_start_date: Date;
     proposed_end_date: Date;
     proposed_start_time?: Date;
     proposed_end_time?: Date;
-    work_category: WorkCategory;
+    work_category: WorkCategoryResponse;
     work_category_string: string;
-    alteration_status: AlterationStatus;
+    alteration_status: AlterationStatusResponse;
     alteration_status_string: string;
-    alteration_type: AlterationType;
+    alteration_type: AlterationTypeResponse;
     alteration_type_string: string;
     date_created: Date;
     deadline_date: Date;
     status_changed_date: Date;
-    lane_rental_assessment_outcome?: LaneRentalAssessmentOutcome;
+    lane_rental_assessment_outcome?: LaneRentalAssessmentOutcomeResponse;
     lane_rental_assessment_outcome_string?: string;
     lane_rental_charges_not_agreed: boolean;
     lane_rental_charges_potentially_apply: boolean;

--- a/dist/interfaces/commentReportingResponse.d.ts
+++ b/dist/interfaces/commentReportingResponse.d.ts
@@ -1,11 +1,11 @@
-import { CommentTopic } from './referenceTypes';
+import { CommentTopicResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface CommentReportingResponse extends ReportingResponse {
     rows: CommentSummaryResponse[];
 }
 export interface CommentSummaryResponse {
     work_reference_number: string;
-    topic: CommentTopic;
+    topic: CommentTopicResponse;
     topic_string: string;
     author_email_address: string;
     author_organisation_reference: string;

--- a/dist/interfaces/csvExportReportingResponse.d.ts
+++ b/dist/interfaces/csvExportReportingResponse.d.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse';
-import { CSVExportStatus } from './referenceTypes';
+import { CSVExportStatusResponse } from './referenceTypes';
 export interface CSVExportReportingResponse extends ReportingResponse {
     rows: CSVExportSummaryResponse[];
 }
@@ -7,7 +7,7 @@ export interface CSVExportSummaryResponse {
     csv_export_id: number;
     filename: string;
     date_created: Date;
-    csv_export_status: CSVExportStatus;
+    csv_export_status: CSVExportStatusResponse;
     csv_export_status_string: string;
     username: string;
 }

--- a/dist/interfaces/forwardPlanReportingResponse.d.ts
+++ b/dist/interfaces/forwardPlanReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { ForwardPlanStatus } from './referenceTypes';
+import { ForwardPlanStatusResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface ForwardPlanReportingResponse extends ReportingResponse {
     rows: ForwardPlanSummaryResponse[];
@@ -14,7 +14,7 @@ export interface ForwardPlanSummaryResponse {
     area: string;
     proposed_start_date: Date;
     proposed_end_date: Date;
-    forward_plan_status: ForwardPlanStatus;
+    forward_plan_status: ForwardPlanStatusResponse;
     forward_plan_status_string: string;
     date_created: Date;
 }

--- a/dist/interfaces/fpnReportingResponse.d.ts
+++ b/dist/interfaces/fpnReportingResponse.d.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse';
-import { FPNStatus, OffenceCode } from './referenceTypes';
+import { FPNStatusResponse, OffenceCodeResponse } from './referenceTypes';
 export interface FPNReportingResponse extends ReportingResponse {
     rows: FPNSummaryResponse[];
 }
@@ -8,11 +8,11 @@ export interface FPNSummaryResponse {
     work_reference_number: string;
     promoter: string;
     highway_authority: string;
-    offence_code: OffenceCode;
+    offence_code: OffenceCodeResponse;
     offence_code_string: string;
     street_name: string;
     issue_date: Date;
-    status: FPNStatus;
+    status: FPNStatusResponse;
     status_string: string;
     status_changed_date: Date;
 }

--- a/dist/interfaces/inspectionReportingResponse.d.ts
+++ b/dist/interfaces/inspectionReportingResponse.d.ts
@@ -1,11 +1,11 @@
 import { ReportingResponse } from './reportingResponse';
-import { InspectionResponseType, InspectionType, InspectionCategory, InspectionOutcome, InspectionStatusResponse } from './referenceTypes';
+import { InspectionCategoryResponse, InspectionOutcomeResponse, InspectionResponseTypeResponse, InspectionTypeResponse, InspectionStatusResponse } from './referenceTypes';
 export interface InspectionReportingResponse extends ReportingResponse {
     rows: InspectionSummaryResponse[];
 }
 export interface InspectionSummaryResponse {
     inspection_date: Date;
-    inspection_response_type: InspectionResponseType;
+    inspection_response_type: InspectionResponseTypeResponse;
     inspection_response_type_string: string;
     work_reference_number: string;
     location_description: string;
@@ -13,11 +13,11 @@ export interface InspectionSummaryResponse {
     town: string;
     area: string;
     inspection_reference_number?: string;
-    inspection_type: InspectionType;
+    inspection_type: InspectionTypeResponse;
     inspection_type_string: string;
-    inspection_category?: InspectionCategory;
+    inspection_category?: InspectionCategoryResponse;
     inspection_category_string?: string;
-    inspection_outcome?: InspectionOutcome;
+    inspection_outcome?: InspectionOutcomeResponse;
     inspection_outcome_string?: string;
     reinspection_date_time?: Date;
     highway_authority: string;

--- a/dist/interfaces/permitCondition.d.ts
+++ b/dist/interfaces/permitCondition.d.ts
@@ -1,6 +1,6 @@
-import { PermitConditionType } from './referenceTypes';
+import { PermitConditionTypeResponse } from './referenceTypes';
 export interface PermitCondition {
-    condition: PermitConditionType;
+    condition: PermitConditionTypeResponse;
     condition_string: string;
     comment?: string;
 }

--- a/dist/interfaces/permitReportingResponse.d.ts
+++ b/dist/interfaces/permitReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { PermitStatus, WorkCategory, TrafficManagementType, WorkStatus, LaneRentalAssessmentOutcome, AssessmentStatus } from './referenceTypes';
+import { WorkCategoryResponse, TrafficManagementTypeResponse, AssessmentStatusResponse, PermitStatusResponse, WorkStatusResponse, LaneRentalAssessmentOutcomeResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 import { PermitCondition } from './permitCondition';
 export interface PermitReportingResponse extends ReportingResponse {
@@ -15,12 +15,12 @@ export interface PermitSummaryResponse {
     street: string;
     town: string;
     area: string;
-    work_category: WorkCategory;
+    work_category: WorkCategoryResponse;
     work_category_string: string;
     description_of_work: string;
-    traffic_management_type: TrafficManagementType;
+    traffic_management_type: TrafficManagementTypeResponse;
     traffic_management_type_string: string;
-    assessment_status?: AssessmentStatus;
+    assessment_status?: AssessmentStatusResponse;
     assessment_status_string?: string;
     proposed_start_date: Date;
     proposed_end_date: Date;
@@ -28,9 +28,9 @@ export interface PermitSummaryResponse {
     proposed_end_time?: Date;
     actual_start_date?: Date;
     actual_end_date?: Date;
-    status: PermitStatus;
+    status: PermitStatusResponse;
     status_string: string;
-    work_status: WorkStatus;
+    work_status: WorkStatusResponse;
     work_status_string: string;
     deadline_date: Date;
     date_created: Date;
@@ -46,7 +46,7 @@ export interface PermitSummaryResponse {
     is_early_start: boolean;
     is_high_impact_traffic_management: boolean;
     is_lane_rental: boolean;
-    lane_rental_assessment_outcome?: LaneRentalAssessmentOutcome;
+    lane_rental_assessment_outcome?: LaneRentalAssessmentOutcomeResponse;
     lane_rental_assessment_outcome_string?: string;
     lane_rental_charges_not_agreed: boolean;
     lane_rental_charges_potentially_apply: boolean;

--- a/dist/interfaces/referenceTypes.d.ts
+++ b/dist/interfaces/referenceTypes.d.ts
@@ -8,6 +8,17 @@ export declare enum PermitStatus {
     revoked = "revoked",
     progressed = "progressed"
 }
+export declare enum PermitStatusResponse {
+    submitted = "submitted",
+    granted = "granted",
+    permit_modification_request = "permit_modification_request",
+    refused = "refused",
+    closed = "closed",
+    cancelled = "cancelled",
+    revoked = "revoked",
+    progressed = "progressed",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum AssessmentStatus {
     granted = "granted",
     granted_auto = "granted_auto",
@@ -16,9 +27,23 @@ export declare enum AssessmentStatus {
     permit_modification_request = "permit_modification_request",
     revoked = "revoked"
 }
+export declare enum AssessmentStatusResponse {
+    granted = "granted",
+    granted_auto = "granted_auto",
+    refused = "refused",
+    refused_auto = "refused_auto",
+    permit_modification_request = "permit_modification_request",
+    revoked = "revoked",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum ReinstatementStatus {
     interim = "interim",
     permanent = "permanent"
+}
+export declare enum ReinstatementStatusResponse {
+    interim = "interim",
+    permanent = "permanent",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum FPNStatus {
     issued = "issued",
@@ -28,15 +53,36 @@ export declare enum FPNStatus {
     disputed = "disputed",
     withdrawn = "withdrawn"
 }
+export declare enum FPNStatusResponse {
+    issued = "issued",
+    accepted = "accepted",
+    paid = "paid",
+    paid_discounted = "paid_discounted",
+    disputed = "disputed",
+    withdrawn = "withdrawn",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum WorkstreamStatus {
     active = "active",
     deactivated = "deactivated"
+}
+export declare enum WorkstreamStatusResponse {
+    active = "active",
+    deactivated = "deactivated",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum OffenceCode {
     offence_code_05 = "offence_code_05",
     offence_code_06 = "offence_code_06",
     offence_code_08 = "offence_code_08",
     offence_code_09 = "offence_code_09"
+}
+export declare enum OffenceCodeResponse {
+    offence_code_05 = "offence_code_05",
+    offence_code_06 = "offence_code_06",
+    offence_code_08 = "offence_code_08",
+    offence_code_09 = "offence_code_09",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum CommentTopic {
     GENERAL = "GENERAL",
@@ -49,6 +95,19 @@ export declare enum CommentTopic {
     IMPOSED_VARIATION = "IMPOSED_VARIATION",
     DURATION_CHALLENGE = "DURATION_CHALLENGE",
     SECTION_81 = "SECTION_81"
+}
+export declare enum CommentTopicResponse {
+    GENERAL = "GENERAL",
+    SECTION_74 = "SECTION_74",
+    INSPECTION = "INSPECTION",
+    FPN = "FPN",
+    OVERRUN = "OVERRUN",
+    FORWARD_PLAN = "FORWARD_PLAN",
+    CHANGE_REQUEST = "CHANGE_REQUEST",
+    IMPOSED_VARIATION = "IMPOSED_VARIATION",
+    DURATION_CHALLENGE = "DURATION_CHALLENGE",
+    SECTION_81 = "SECTION_81",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum SortDirection {
     asc = "asc",
@@ -80,9 +139,21 @@ export declare enum InspectionType {
     non_compliance_follow_up = "non_compliance_follow_up",
     section_81 = "section_81"
 }
+export declare enum InspectionTypeResponse {
+    live_site = "live_site",
+    reinstatement = "reinstatement",
+    non_compliance_follow_up = "non_compliance_follow_up",
+    section_81 = "section_81",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum InspectionResponseType {
     inspection = "inspection",
     reinspection = "reinspection"
+}
+export declare enum InspectionResponseTypeResponse {
+    inspection = "inspection",
+    reinspection = "reinspection",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum InspectionCategory {
     a = "a",
@@ -95,6 +166,19 @@ export declare enum InspectionCategory {
     follow_up_completion = "follow_up_completion",
     site_occupancy = "site_occupancy",
     conditions = "conditions"
+}
+export declare enum InspectionCategoryResponse {
+    a = "a",
+    b = "b",
+    c = "c",
+    third_party = "third_party",
+    routine = "routine",
+    joint_site_visit = "joint_site_visit",
+    follow_up = "follow_up",
+    follow_up_completion = "follow_up_completion",
+    site_occupancy = "site_occupancy",
+    conditions = "conditions",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum InspectionOutcome {
     passed = "passed",
@@ -109,6 +193,20 @@ export declare enum InspectionOutcome {
     works_in_progress = "works_in_progress",
     works_stopped = "works_stopped"
 }
+export declare enum InspectionOutcomeResponse {
+    passed = "passed",
+    unable_to_complete_inspection = "unable_to_complete_inspection",
+    failed_low = "failed_low",
+    failed_high = "failed_high",
+    further_inspections_required = "further_inspections_required",
+    agreed_site_compliance = "agreed_site_compliance",
+    non_compliant_with_conditions = "non_compliant_with_conditions",
+    works_stopped_apparatus_remaining = "works_stopped_apparatus_remaining",
+    works_in_progress_no_carriageway_incursion = "works_in_progress_no_carriageway_incursion",
+    works_in_progress = "works_in_progress",
+    works_stopped = "works_stopped",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum InspectionSortColumn {
     inspection_date = "inspection_date"
 }
@@ -120,6 +218,16 @@ export declare enum WorkCategory {
     immediate_emergency = "immediate_emergency",
     paa = "paa",
     hs2_highway = "hs2_highway"
+}
+export declare enum WorkCategoryResponse {
+    minor = "minor",
+    standard = "standard",
+    major = "major",
+    immediate_urgent = "immediate_urgent",
+    immediate_emergency = "immediate_emergency",
+    paa = "paa",
+    hs2_highway = "hs2_highway",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum TrafficManagementType {
     road_closure = "road_closure",
@@ -134,6 +242,20 @@ export declare enum TrafficManagementType {
     some_carriageway_incursion = "some_carriageway_incursion",
     no_carriageway_incursion = "no_carriageway_incursion"
 }
+export declare enum TrafficManagementTypeResponse {
+    road_closure = "road_closure",
+    contra_flow = "contra_flow",
+    lane_closure = "lane_closure",
+    multi_way_signals = "multi_way_signals",
+    two_way_signals = "two_way_signals",
+    convoy_workings = "convoy_workings",
+    stop_go_boards = "stop_go_boards",
+    priority_working = "priority_working",
+    give_and_take = "give_and_take",
+    some_carriageway_incursion = "some_carriageway_incursion",
+    no_carriageway_incursion = "no_carriageway_incursion",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum AlterationStatus {
     submitted = "submitted",
     granted = "granted",
@@ -143,6 +265,17 @@ export declare enum AlterationStatus {
     cancelled = "cancelled",
     revoked = "revoked",
     auto_applied = "auto_applied"
+}
+export declare enum AlterationStatusResponse {
+    submitted = "submitted",
+    granted = "granted",
+    granted_with_duration_challenge = "granted_with_duration_challenge",
+    refused = "refused",
+    deemed = "deemed",
+    cancelled = "cancelled",
+    revoked = "revoked",
+    auto_applied = "auto_applied",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum AlterationSortColumn {
     date_created = "date_created",
@@ -159,6 +292,16 @@ export declare enum AlterationType {
     DURATION_CHALLENGE = "DURATION_CHALLENGE",
     MODIFIED_PERMIT = "MODIFIED_PERMIT"
 }
+export declare enum AlterationTypeResponse {
+    PROMOTER_IMPOSED_CHANGE = "PROMOTER_IMPOSED_CHANGE",
+    PROMOTER_CHANGE_REQUEST = "PROMOTER_CHANGE_REQUEST",
+    HA_CHANGE_REQUEST = "HA_CHANGE_REQUEST",
+    HA_IMPOSED_CHANGE = "HA_IMPOSED_CHANGE",
+    WORK_EXTENSION = "WORK_EXTENSION",
+    DURATION_CHALLENGE = "DURATION_CHALLENGE",
+    MODIFIED_PERMIT = "MODIFIED_PERMIT",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum WorkStatus {
     planned = "planned",
     in_progress = "in_progress",
@@ -169,16 +312,33 @@ export declare enum WorkStatus {
     non_notifiable = "non_notifiable",
     section_81 = "section_81"
 }
+export declare enum WorkStatusResponse {
+    planned = "planned",
+    in_progress = "in_progress",
+    completed = "completed",
+    cancelled = "cancelled",
+    unattributable = "unattributable",
+    historical = "historical",
+    non_notifiable = "non_notifiable",
+    section_81 = "section_81",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum ForwardPlanStatus {
     raised = "raised",
     cancelled = "cancelled",
     progressed = "progressed"
 }
+export declare enum ForwardPlanStatusResponse {
+    raised = "raised",
+    cancelled = "cancelled",
+    progressed = "progressed",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum ForwardPlanSortColumn {
     start_date = "start_date",
     end_date = "end_date"
 }
-export declare enum PermitConditionType {
+export declare enum PermitConditionTypeResponse {
     NCT01a = "NCT01a",
     NCT01b = "NCT01b",
     NCT02a = "NCT02a",
@@ -196,7 +356,8 @@ export declare enum PermitConditionType {
     NCT10a = "NCT10a",
     NCT11a = "NCT11a",
     NCT11b = "NCT11b",
-    NCT12a = "NCT12a"
+    NCT12a = "NCT12a",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum LaneRentalAssessmentOutcome {
     chargeable = "chargeable",
@@ -205,11 +366,20 @@ export declare enum LaneRentalAssessmentOutcome {
     exempt = "exempt",
     charges_not_applicable = "charges_not_applicable"
 }
-export declare enum ReinstatementType {
+export declare enum LaneRentalAssessmentOutcomeResponse {
+    chargeable = "chargeable",
+    potentially_chargeable = "potentially_chargeable",
+    charges_waived = "charges_waived",
+    exempt = "exempt",
+    charges_not_applicable = "charges_not_applicable",
+    upcoming_enum = "upcoming_enum"
+}
+export declare enum ReinstatementTypeResponse {
     excavation = "excavation",
     bar_holes = "bar_holes",
     core_holes = "core_holes",
-    pole_testing = "pole_testing"
+    pole_testing = "pole_testing",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum AdditionalSpecialDesignationCode {
     protected_street = 1,
@@ -241,6 +411,11 @@ export declare enum Section81Severity {
     high = "high",
     low = "low"
 }
+export declare enum Section81SeverityResponse {
+    high = "high",
+    low = "low",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum Section81Status {
     issued = "issued",
     acknowledged = "acknowledged",
@@ -250,27 +425,40 @@ export declare enum Section81Status {
     resolved_by_ha = "resolved_by_ha",
     cancelled = "cancelled"
 }
+export declare enum Section81StatusResponse {
+    issued = "issued",
+    acknowledged = "acknowledged",
+    accepted = "accepted",
+    accepted_fixed = "accepted_fixed",
+    rejected = "rejected",
+    resolved_by_ha = "resolved_by_ha",
+    cancelled = "cancelled",
+    upcoming_enum = "upcoming_enum"
+}
 export declare enum Section81SortColumn {
     status_changed_date = "status_changed_date"
 }
-export declare enum Role {
+export declare enum RoleResponse {
     Planner = "Planner",
     HighwayAuthority = "HighwayAuthority",
     Admin = "Admin",
     Contractor = "Contractor",
     API = "API",
     UI = "UI",
-    DataExport = "DataExport"
+    DataExport = "DataExport",
+    upcoming_enum = "upcoming_enum"
 }
-export declare enum WorkstreamAccessLevel {
+export declare enum WorkstreamAccessLevelResponse {
     read_only = "read_only",
-    full_write = "full_write"
+    full_write = "full_write",
+    upcoming_enum = "upcoming_enum"
 }
-export declare enum CSVExportStatus {
+export declare enum CSVExportStatusResponse {
     queued = "queued",
     in_progress = "in_progress",
     ready = "ready",
-    failed = "failed"
+    failed = "failed",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum AuditEventType {
     historic_action = "historic_action",
@@ -374,7 +562,7 @@ export declare enum AuditEventType {
     permit_granted_with_duration_challenge = "permit_granted_with_duration_challenge",
     inspection_withdrawn = "inspection_withdrawn"
 }
-export declare enum AuditObjectType {
+export declare enum AuditObjectTypeResponse {
     PERMIT = "permit",
     REINSTATEMENT = "reinstatement",
     INSPECTION = "inspection",
@@ -391,7 +579,8 @@ export declare enum AuditObjectType {
     USER = "user",
     GEOGRAPHICAL_AREA = "geographical_area",
     CHANGE_REQUEST = "change_request",
-    APPLICATION = "application"
+    APPLICATION = "application",
+    upcoming_enum = "upcoming_enum"
 }
 export declare enum SampleInspectionSortColumn {
     inspection_expiry = "inspection_expiry"

--- a/dist/interfaces/referenceTypes.js
+++ b/dist/interfaces/referenceTypes.js
@@ -11,6 +11,18 @@ var PermitStatus;
     PermitStatus["revoked"] = "revoked";
     PermitStatus["progressed"] = "progressed";
 })(PermitStatus = exports.PermitStatus || (exports.PermitStatus = {}));
+var PermitStatusResponse;
+(function (PermitStatusResponse) {
+    PermitStatusResponse["submitted"] = "submitted";
+    PermitStatusResponse["granted"] = "granted";
+    PermitStatusResponse["permit_modification_request"] = "permit_modification_request";
+    PermitStatusResponse["refused"] = "refused";
+    PermitStatusResponse["closed"] = "closed";
+    PermitStatusResponse["cancelled"] = "cancelled";
+    PermitStatusResponse["revoked"] = "revoked";
+    PermitStatusResponse["progressed"] = "progressed";
+    PermitStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(PermitStatusResponse = exports.PermitStatusResponse || (exports.PermitStatusResponse = {}));
 var AssessmentStatus;
 (function (AssessmentStatus) {
     AssessmentStatus["granted"] = "granted";
@@ -20,11 +32,27 @@ var AssessmentStatus;
     AssessmentStatus["permit_modification_request"] = "permit_modification_request";
     AssessmentStatus["revoked"] = "revoked";
 })(AssessmentStatus = exports.AssessmentStatus || (exports.AssessmentStatus = {}));
+var AssessmentStatusResponse;
+(function (AssessmentStatusResponse) {
+    AssessmentStatusResponse["granted"] = "granted";
+    AssessmentStatusResponse["granted_auto"] = "granted_auto";
+    AssessmentStatusResponse["refused"] = "refused";
+    AssessmentStatusResponse["refused_auto"] = "refused_auto";
+    AssessmentStatusResponse["permit_modification_request"] = "permit_modification_request";
+    AssessmentStatusResponse["revoked"] = "revoked";
+    AssessmentStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(AssessmentStatusResponse = exports.AssessmentStatusResponse || (exports.AssessmentStatusResponse = {}));
 var ReinstatementStatus;
 (function (ReinstatementStatus) {
     ReinstatementStatus["interim"] = "interim";
     ReinstatementStatus["permanent"] = "permanent";
 })(ReinstatementStatus = exports.ReinstatementStatus || (exports.ReinstatementStatus = {}));
+var ReinstatementStatusResponse;
+(function (ReinstatementStatusResponse) {
+    ReinstatementStatusResponse["interim"] = "interim";
+    ReinstatementStatusResponse["permanent"] = "permanent";
+    ReinstatementStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(ReinstatementStatusResponse = exports.ReinstatementStatusResponse || (exports.ReinstatementStatusResponse = {}));
 var FPNStatus;
 (function (FPNStatus) {
     FPNStatus["issued"] = "issued";
@@ -34,11 +62,27 @@ var FPNStatus;
     FPNStatus["disputed"] = "disputed";
     FPNStatus["withdrawn"] = "withdrawn";
 })(FPNStatus = exports.FPNStatus || (exports.FPNStatus = {}));
+var FPNStatusResponse;
+(function (FPNStatusResponse) {
+    FPNStatusResponse["issued"] = "issued";
+    FPNStatusResponse["accepted"] = "accepted";
+    FPNStatusResponse["paid"] = "paid";
+    FPNStatusResponse["paid_discounted"] = "paid_discounted";
+    FPNStatusResponse["disputed"] = "disputed";
+    FPNStatusResponse["withdrawn"] = "withdrawn";
+    FPNStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(FPNStatusResponse = exports.FPNStatusResponse || (exports.FPNStatusResponse = {}));
 var WorkstreamStatus;
 (function (WorkstreamStatus) {
     WorkstreamStatus["active"] = "active";
     WorkstreamStatus["deactivated"] = "deactivated";
 })(WorkstreamStatus = exports.WorkstreamStatus || (exports.WorkstreamStatus = {}));
+var WorkstreamStatusResponse;
+(function (WorkstreamStatusResponse) {
+    WorkstreamStatusResponse["active"] = "active";
+    WorkstreamStatusResponse["deactivated"] = "deactivated";
+    WorkstreamStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(WorkstreamStatusResponse = exports.WorkstreamStatusResponse || (exports.WorkstreamStatusResponse = {}));
 var OffenceCode;
 (function (OffenceCode) {
     OffenceCode["offence_code_05"] = "offence_code_05";
@@ -46,6 +90,14 @@ var OffenceCode;
     OffenceCode["offence_code_08"] = "offence_code_08";
     OffenceCode["offence_code_09"] = "offence_code_09";
 })(OffenceCode = exports.OffenceCode || (exports.OffenceCode = {}));
+var OffenceCodeResponse;
+(function (OffenceCodeResponse) {
+    OffenceCodeResponse["offence_code_05"] = "offence_code_05";
+    OffenceCodeResponse["offence_code_06"] = "offence_code_06";
+    OffenceCodeResponse["offence_code_08"] = "offence_code_08";
+    OffenceCodeResponse["offence_code_09"] = "offence_code_09";
+    OffenceCodeResponse["upcoming_enum"] = "upcoming_enum";
+})(OffenceCodeResponse = exports.OffenceCodeResponse || (exports.OffenceCodeResponse = {}));
 var CommentTopic;
 (function (CommentTopic) {
     CommentTopic["GENERAL"] = "GENERAL";
@@ -59,6 +111,20 @@ var CommentTopic;
     CommentTopic["DURATION_CHALLENGE"] = "DURATION_CHALLENGE";
     CommentTopic["SECTION_81"] = "SECTION_81";
 })(CommentTopic = exports.CommentTopic || (exports.CommentTopic = {}));
+var CommentTopicResponse;
+(function (CommentTopicResponse) {
+    CommentTopicResponse["GENERAL"] = "GENERAL";
+    CommentTopicResponse["SECTION_74"] = "SECTION_74";
+    CommentTopicResponse["INSPECTION"] = "INSPECTION";
+    CommentTopicResponse["FPN"] = "FPN";
+    CommentTopicResponse["OVERRUN"] = "OVERRUN";
+    CommentTopicResponse["FORWARD_PLAN"] = "FORWARD_PLAN";
+    CommentTopicResponse["CHANGE_REQUEST"] = "CHANGE_REQUEST";
+    CommentTopicResponse["IMPOSED_VARIATION"] = "IMPOSED_VARIATION";
+    CommentTopicResponse["DURATION_CHALLENGE"] = "DURATION_CHALLENGE";
+    CommentTopicResponse["SECTION_81"] = "SECTION_81";
+    CommentTopicResponse["upcoming_enum"] = "upcoming_enum";
+})(CommentTopicResponse = exports.CommentTopicResponse || (exports.CommentTopicResponse = {}));
 var SortDirection;
 (function (SortDirection) {
     SortDirection["asc"] = "asc";
@@ -96,11 +162,25 @@ var InspectionType;
     InspectionType["non_compliance_follow_up"] = "non_compliance_follow_up";
     InspectionType["section_81"] = "section_81";
 })(InspectionType = exports.InspectionType || (exports.InspectionType = {}));
+var InspectionTypeResponse;
+(function (InspectionTypeResponse) {
+    InspectionTypeResponse["live_site"] = "live_site";
+    InspectionTypeResponse["reinstatement"] = "reinstatement";
+    InspectionTypeResponse["non_compliance_follow_up"] = "non_compliance_follow_up";
+    InspectionTypeResponse["section_81"] = "section_81";
+    InspectionTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(InspectionTypeResponse = exports.InspectionTypeResponse || (exports.InspectionTypeResponse = {}));
 var InspectionResponseType;
 (function (InspectionResponseType) {
     InspectionResponseType["inspection"] = "inspection";
     InspectionResponseType["reinspection"] = "reinspection";
 })(InspectionResponseType = exports.InspectionResponseType || (exports.InspectionResponseType = {}));
+var InspectionResponseTypeResponse;
+(function (InspectionResponseTypeResponse) {
+    InspectionResponseTypeResponse["inspection"] = "inspection";
+    InspectionResponseTypeResponse["reinspection"] = "reinspection";
+    InspectionResponseTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(InspectionResponseTypeResponse = exports.InspectionResponseTypeResponse || (exports.InspectionResponseTypeResponse = {}));
 var InspectionCategory;
 (function (InspectionCategory) {
     InspectionCategory["a"] = "a";
@@ -114,6 +194,20 @@ var InspectionCategory;
     InspectionCategory["site_occupancy"] = "site_occupancy";
     InspectionCategory["conditions"] = "conditions";
 })(InspectionCategory = exports.InspectionCategory || (exports.InspectionCategory = {}));
+var InspectionCategoryResponse;
+(function (InspectionCategoryResponse) {
+    InspectionCategoryResponse["a"] = "a";
+    InspectionCategoryResponse["b"] = "b";
+    InspectionCategoryResponse["c"] = "c";
+    InspectionCategoryResponse["third_party"] = "third_party";
+    InspectionCategoryResponse["routine"] = "routine";
+    InspectionCategoryResponse["joint_site_visit"] = "joint_site_visit";
+    InspectionCategoryResponse["follow_up"] = "follow_up";
+    InspectionCategoryResponse["follow_up_completion"] = "follow_up_completion";
+    InspectionCategoryResponse["site_occupancy"] = "site_occupancy";
+    InspectionCategoryResponse["conditions"] = "conditions";
+    InspectionCategoryResponse["upcoming_enum"] = "upcoming_enum";
+})(InspectionCategoryResponse = exports.InspectionCategoryResponse || (exports.InspectionCategoryResponse = {}));
 var InspectionOutcome;
 (function (InspectionOutcome) {
     InspectionOutcome["passed"] = "passed";
@@ -128,6 +222,21 @@ var InspectionOutcome;
     InspectionOutcome["works_in_progress"] = "works_in_progress";
     InspectionOutcome["works_stopped"] = "works_stopped";
 })(InspectionOutcome = exports.InspectionOutcome || (exports.InspectionOutcome = {}));
+var InspectionOutcomeResponse;
+(function (InspectionOutcomeResponse) {
+    InspectionOutcomeResponse["passed"] = "passed";
+    InspectionOutcomeResponse["unable_to_complete_inspection"] = "unable_to_complete_inspection";
+    InspectionOutcomeResponse["failed_low"] = "failed_low";
+    InspectionOutcomeResponse["failed_high"] = "failed_high";
+    InspectionOutcomeResponse["further_inspections_required"] = "further_inspections_required";
+    InspectionOutcomeResponse["agreed_site_compliance"] = "agreed_site_compliance";
+    InspectionOutcomeResponse["non_compliant_with_conditions"] = "non_compliant_with_conditions";
+    InspectionOutcomeResponse["works_stopped_apparatus_remaining"] = "works_stopped_apparatus_remaining";
+    InspectionOutcomeResponse["works_in_progress_no_carriageway_incursion"] = "works_in_progress_no_carriageway_incursion";
+    InspectionOutcomeResponse["works_in_progress"] = "works_in_progress";
+    InspectionOutcomeResponse["works_stopped"] = "works_stopped";
+    InspectionOutcomeResponse["upcoming_enum"] = "upcoming_enum";
+})(InspectionOutcomeResponse = exports.InspectionOutcomeResponse || (exports.InspectionOutcomeResponse = {}));
 var InspectionSortColumn;
 (function (InspectionSortColumn) {
     InspectionSortColumn["inspection_date"] = "inspection_date";
@@ -142,6 +251,17 @@ var WorkCategory;
     WorkCategory["paa"] = "paa";
     WorkCategory["hs2_highway"] = "hs2_highway";
 })(WorkCategory = exports.WorkCategory || (exports.WorkCategory = {}));
+var WorkCategoryResponse;
+(function (WorkCategoryResponse) {
+    WorkCategoryResponse["minor"] = "minor";
+    WorkCategoryResponse["standard"] = "standard";
+    WorkCategoryResponse["major"] = "major";
+    WorkCategoryResponse["immediate_urgent"] = "immediate_urgent";
+    WorkCategoryResponse["immediate_emergency"] = "immediate_emergency";
+    WorkCategoryResponse["paa"] = "paa";
+    WorkCategoryResponse["hs2_highway"] = "hs2_highway";
+    WorkCategoryResponse["upcoming_enum"] = "upcoming_enum";
+})(WorkCategoryResponse = exports.WorkCategoryResponse || (exports.WorkCategoryResponse = {}));
 var TrafficManagementType;
 (function (TrafficManagementType) {
     TrafficManagementType["road_closure"] = "road_closure";
@@ -156,6 +276,21 @@ var TrafficManagementType;
     TrafficManagementType["some_carriageway_incursion"] = "some_carriageway_incursion";
     TrafficManagementType["no_carriageway_incursion"] = "no_carriageway_incursion";
 })(TrafficManagementType = exports.TrafficManagementType || (exports.TrafficManagementType = {}));
+var TrafficManagementTypeResponse;
+(function (TrafficManagementTypeResponse) {
+    TrafficManagementTypeResponse["road_closure"] = "road_closure";
+    TrafficManagementTypeResponse["contra_flow"] = "contra_flow";
+    TrafficManagementTypeResponse["lane_closure"] = "lane_closure";
+    TrafficManagementTypeResponse["multi_way_signals"] = "multi_way_signals";
+    TrafficManagementTypeResponse["two_way_signals"] = "two_way_signals";
+    TrafficManagementTypeResponse["convoy_workings"] = "convoy_workings";
+    TrafficManagementTypeResponse["stop_go_boards"] = "stop_go_boards";
+    TrafficManagementTypeResponse["priority_working"] = "priority_working";
+    TrafficManagementTypeResponse["give_and_take"] = "give_and_take";
+    TrafficManagementTypeResponse["some_carriageway_incursion"] = "some_carriageway_incursion";
+    TrafficManagementTypeResponse["no_carriageway_incursion"] = "no_carriageway_incursion";
+    TrafficManagementTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(TrafficManagementTypeResponse = exports.TrafficManagementTypeResponse || (exports.TrafficManagementTypeResponse = {}));
 var AlterationStatus;
 (function (AlterationStatus) {
     AlterationStatus["submitted"] = "submitted";
@@ -167,6 +302,18 @@ var AlterationStatus;
     AlterationStatus["revoked"] = "revoked";
     AlterationStatus["auto_applied"] = "auto_applied";
 })(AlterationStatus = exports.AlterationStatus || (exports.AlterationStatus = {}));
+var AlterationStatusResponse;
+(function (AlterationStatusResponse) {
+    AlterationStatusResponse["submitted"] = "submitted";
+    AlterationStatusResponse["granted"] = "granted";
+    AlterationStatusResponse["granted_with_duration_challenge"] = "granted_with_duration_challenge";
+    AlterationStatusResponse["refused"] = "refused";
+    AlterationStatusResponse["deemed"] = "deemed";
+    AlterationStatusResponse["cancelled"] = "cancelled";
+    AlterationStatusResponse["revoked"] = "revoked";
+    AlterationStatusResponse["auto_applied"] = "auto_applied";
+    AlterationStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(AlterationStatusResponse = exports.AlterationStatusResponse || (exports.AlterationStatusResponse = {}));
 var AlterationSortColumn;
 (function (AlterationSortColumn) {
     AlterationSortColumn["date_created"] = "date_created";
@@ -184,6 +331,17 @@ var AlterationType;
     AlterationType["DURATION_CHALLENGE"] = "DURATION_CHALLENGE";
     AlterationType["MODIFIED_PERMIT"] = "MODIFIED_PERMIT";
 })(AlterationType = exports.AlterationType || (exports.AlterationType = {}));
+var AlterationTypeResponse;
+(function (AlterationTypeResponse) {
+    AlterationTypeResponse["PROMOTER_IMPOSED_CHANGE"] = "PROMOTER_IMPOSED_CHANGE";
+    AlterationTypeResponse["PROMOTER_CHANGE_REQUEST"] = "PROMOTER_CHANGE_REQUEST";
+    AlterationTypeResponse["HA_CHANGE_REQUEST"] = "HA_CHANGE_REQUEST";
+    AlterationTypeResponse["HA_IMPOSED_CHANGE"] = "HA_IMPOSED_CHANGE";
+    AlterationTypeResponse["WORK_EXTENSION"] = "WORK_EXTENSION";
+    AlterationTypeResponse["DURATION_CHALLENGE"] = "DURATION_CHALLENGE";
+    AlterationTypeResponse["MODIFIED_PERMIT"] = "MODIFIED_PERMIT";
+    AlterationTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(AlterationTypeResponse = exports.AlterationTypeResponse || (exports.AlterationTypeResponse = {}));
 var WorkStatus;
 (function (WorkStatus) {
     WorkStatus["planned"] = "planned";
@@ -195,38 +353,58 @@ var WorkStatus;
     WorkStatus["non_notifiable"] = "non_notifiable";
     WorkStatus["section_81"] = "section_81";
 })(WorkStatus = exports.WorkStatus || (exports.WorkStatus = {}));
+var WorkStatusResponse;
+(function (WorkStatusResponse) {
+    WorkStatusResponse["planned"] = "planned";
+    WorkStatusResponse["in_progress"] = "in_progress";
+    WorkStatusResponse["completed"] = "completed";
+    WorkStatusResponse["cancelled"] = "cancelled";
+    WorkStatusResponse["unattributable"] = "unattributable";
+    WorkStatusResponse["historical"] = "historical";
+    WorkStatusResponse["non_notifiable"] = "non_notifiable";
+    WorkStatusResponse["section_81"] = "section_81";
+    WorkStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(WorkStatusResponse = exports.WorkStatusResponse || (exports.WorkStatusResponse = {}));
 var ForwardPlanStatus;
 (function (ForwardPlanStatus) {
     ForwardPlanStatus["raised"] = "raised";
     ForwardPlanStatus["cancelled"] = "cancelled";
     ForwardPlanStatus["progressed"] = "progressed";
 })(ForwardPlanStatus = exports.ForwardPlanStatus || (exports.ForwardPlanStatus = {}));
+var ForwardPlanStatusResponse;
+(function (ForwardPlanStatusResponse) {
+    ForwardPlanStatusResponse["raised"] = "raised";
+    ForwardPlanStatusResponse["cancelled"] = "cancelled";
+    ForwardPlanStatusResponse["progressed"] = "progressed";
+    ForwardPlanStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(ForwardPlanStatusResponse = exports.ForwardPlanStatusResponse || (exports.ForwardPlanStatusResponse = {}));
 var ForwardPlanSortColumn;
 (function (ForwardPlanSortColumn) {
     ForwardPlanSortColumn["start_date"] = "start_date";
     ForwardPlanSortColumn["end_date"] = "end_date";
 })(ForwardPlanSortColumn = exports.ForwardPlanSortColumn || (exports.ForwardPlanSortColumn = {}));
-var PermitConditionType;
-(function (PermitConditionType) {
-    PermitConditionType["NCT01a"] = "NCT01a";
-    PermitConditionType["NCT01b"] = "NCT01b";
-    PermitConditionType["NCT02a"] = "NCT02a";
-    PermitConditionType["NCT02b"] = "NCT02b";
-    PermitConditionType["NCT04a"] = "NCT04a";
-    PermitConditionType["NCT04b"] = "NCT04b";
-    PermitConditionType["NCT05a"] = "NCT05a";
-    PermitConditionType["NCT06a"] = "NCT06a";
-    PermitConditionType["NCT07a"] = "NCT07a";
-    PermitConditionType["NCT08a"] = "NCT08a";
-    PermitConditionType["NCT08b"] = "NCT08b";
-    PermitConditionType["NCT09a"] = "NCT09a";
-    PermitConditionType["NCT09b"] = "NCT09b";
-    PermitConditionType["NCT09c"] = "NCT09c";
-    PermitConditionType["NCT10a"] = "NCT10a";
-    PermitConditionType["NCT11a"] = "NCT11a";
-    PermitConditionType["NCT11b"] = "NCT11b";
-    PermitConditionType["NCT12a"] = "NCT12a";
-})(PermitConditionType = exports.PermitConditionType || (exports.PermitConditionType = {}));
+var PermitConditionTypeResponse;
+(function (PermitConditionTypeResponse) {
+    PermitConditionTypeResponse["NCT01a"] = "NCT01a";
+    PermitConditionTypeResponse["NCT01b"] = "NCT01b";
+    PermitConditionTypeResponse["NCT02a"] = "NCT02a";
+    PermitConditionTypeResponse["NCT02b"] = "NCT02b";
+    PermitConditionTypeResponse["NCT04a"] = "NCT04a";
+    PermitConditionTypeResponse["NCT04b"] = "NCT04b";
+    PermitConditionTypeResponse["NCT05a"] = "NCT05a";
+    PermitConditionTypeResponse["NCT06a"] = "NCT06a";
+    PermitConditionTypeResponse["NCT07a"] = "NCT07a";
+    PermitConditionTypeResponse["NCT08a"] = "NCT08a";
+    PermitConditionTypeResponse["NCT08b"] = "NCT08b";
+    PermitConditionTypeResponse["NCT09a"] = "NCT09a";
+    PermitConditionTypeResponse["NCT09b"] = "NCT09b";
+    PermitConditionTypeResponse["NCT09c"] = "NCT09c";
+    PermitConditionTypeResponse["NCT10a"] = "NCT10a";
+    PermitConditionTypeResponse["NCT11a"] = "NCT11a";
+    PermitConditionTypeResponse["NCT11b"] = "NCT11b";
+    PermitConditionTypeResponse["NCT12a"] = "NCT12a";
+    PermitConditionTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(PermitConditionTypeResponse = exports.PermitConditionTypeResponse || (exports.PermitConditionTypeResponse = {}));
 var LaneRentalAssessmentOutcome;
 (function (LaneRentalAssessmentOutcome) {
     LaneRentalAssessmentOutcome["chargeable"] = "chargeable";
@@ -235,13 +413,23 @@ var LaneRentalAssessmentOutcome;
     LaneRentalAssessmentOutcome["exempt"] = "exempt";
     LaneRentalAssessmentOutcome["charges_not_applicable"] = "charges_not_applicable";
 })(LaneRentalAssessmentOutcome = exports.LaneRentalAssessmentOutcome || (exports.LaneRentalAssessmentOutcome = {}));
-var ReinstatementType;
-(function (ReinstatementType) {
-    ReinstatementType["excavation"] = "excavation";
-    ReinstatementType["bar_holes"] = "bar_holes";
-    ReinstatementType["core_holes"] = "core_holes";
-    ReinstatementType["pole_testing"] = "pole_testing";
-})(ReinstatementType = exports.ReinstatementType || (exports.ReinstatementType = {}));
+var LaneRentalAssessmentOutcomeResponse;
+(function (LaneRentalAssessmentOutcomeResponse) {
+    LaneRentalAssessmentOutcomeResponse["chargeable"] = "chargeable";
+    LaneRentalAssessmentOutcomeResponse["potentially_chargeable"] = "potentially_chargeable";
+    LaneRentalAssessmentOutcomeResponse["charges_waived"] = "charges_waived";
+    LaneRentalAssessmentOutcomeResponse["exempt"] = "exempt";
+    LaneRentalAssessmentOutcomeResponse["charges_not_applicable"] = "charges_not_applicable";
+    LaneRentalAssessmentOutcomeResponse["upcoming_enum"] = "upcoming_enum";
+})(LaneRentalAssessmentOutcomeResponse = exports.LaneRentalAssessmentOutcomeResponse || (exports.LaneRentalAssessmentOutcomeResponse = {}));
+var ReinstatementTypeResponse;
+(function (ReinstatementTypeResponse) {
+    ReinstatementTypeResponse["excavation"] = "excavation";
+    ReinstatementTypeResponse["bar_holes"] = "bar_holes";
+    ReinstatementTypeResponse["core_holes"] = "core_holes";
+    ReinstatementTypeResponse["pole_testing"] = "pole_testing";
+    ReinstatementTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(ReinstatementTypeResponse = exports.ReinstatementTypeResponse || (exports.ReinstatementTypeResponse = {}));
 var AdditionalSpecialDesignationCode;
 (function (AdditionalSpecialDesignationCode) {
     AdditionalSpecialDesignationCode[AdditionalSpecialDesignationCode["protected_street"] = 1] = "protected_street";
@@ -274,6 +462,12 @@ var Section81Severity;
     Section81Severity["high"] = "high";
     Section81Severity["low"] = "low";
 })(Section81Severity = exports.Section81Severity || (exports.Section81Severity = {}));
+var Section81SeverityResponse;
+(function (Section81SeverityResponse) {
+    Section81SeverityResponse["high"] = "high";
+    Section81SeverityResponse["low"] = "low";
+    Section81SeverityResponse["upcoming_enum"] = "upcoming_enum";
+})(Section81SeverityResponse = exports.Section81SeverityResponse || (exports.Section81SeverityResponse = {}));
 var Section81Status;
 (function (Section81Status) {
     Section81Status["issued"] = "issued";
@@ -284,32 +478,46 @@ var Section81Status;
     Section81Status["resolved_by_ha"] = "resolved_by_ha";
     Section81Status["cancelled"] = "cancelled";
 })(Section81Status = exports.Section81Status || (exports.Section81Status = {}));
+var Section81StatusResponse;
+(function (Section81StatusResponse) {
+    Section81StatusResponse["issued"] = "issued";
+    Section81StatusResponse["acknowledged"] = "acknowledged";
+    Section81StatusResponse["accepted"] = "accepted";
+    Section81StatusResponse["accepted_fixed"] = "accepted_fixed";
+    Section81StatusResponse["rejected"] = "rejected";
+    Section81StatusResponse["resolved_by_ha"] = "resolved_by_ha";
+    Section81StatusResponse["cancelled"] = "cancelled";
+    Section81StatusResponse["upcoming_enum"] = "upcoming_enum";
+})(Section81StatusResponse = exports.Section81StatusResponse || (exports.Section81StatusResponse = {}));
 var Section81SortColumn;
 (function (Section81SortColumn) {
     Section81SortColumn["status_changed_date"] = "status_changed_date";
 })(Section81SortColumn = exports.Section81SortColumn || (exports.Section81SortColumn = {}));
-var Role;
-(function (Role) {
-    Role["Planner"] = "Planner";
-    Role["HighwayAuthority"] = "HighwayAuthority";
-    Role["Admin"] = "Admin";
-    Role["Contractor"] = "Contractor";
-    Role["API"] = "API";
-    Role["UI"] = "UI";
-    Role["DataExport"] = "DataExport";
-})(Role = exports.Role || (exports.Role = {}));
-var WorkstreamAccessLevel;
-(function (WorkstreamAccessLevel) {
-    WorkstreamAccessLevel["read_only"] = "read_only";
-    WorkstreamAccessLevel["full_write"] = "full_write";
-})(WorkstreamAccessLevel = exports.WorkstreamAccessLevel || (exports.WorkstreamAccessLevel = {}));
-var CSVExportStatus;
-(function (CSVExportStatus) {
-    CSVExportStatus["queued"] = "queued";
-    CSVExportStatus["in_progress"] = "in_progress";
-    CSVExportStatus["ready"] = "ready";
-    CSVExportStatus["failed"] = "failed";
-})(CSVExportStatus = exports.CSVExportStatus || (exports.CSVExportStatus = {}));
+var RoleResponse;
+(function (RoleResponse) {
+    RoleResponse["Planner"] = "Planner";
+    RoleResponse["HighwayAuthority"] = "HighwayAuthority";
+    RoleResponse["Admin"] = "Admin";
+    RoleResponse["Contractor"] = "Contractor";
+    RoleResponse["API"] = "API";
+    RoleResponse["UI"] = "UI";
+    RoleResponse["DataExport"] = "DataExport";
+    RoleResponse["upcoming_enum"] = "upcoming_enum";
+})(RoleResponse = exports.RoleResponse || (exports.RoleResponse = {}));
+var WorkstreamAccessLevelResponse;
+(function (WorkstreamAccessLevelResponse) {
+    WorkstreamAccessLevelResponse["read_only"] = "read_only";
+    WorkstreamAccessLevelResponse["full_write"] = "full_write";
+    WorkstreamAccessLevelResponse["upcoming_enum"] = "upcoming_enum";
+})(WorkstreamAccessLevelResponse = exports.WorkstreamAccessLevelResponse || (exports.WorkstreamAccessLevelResponse = {}));
+var CSVExportStatusResponse;
+(function (CSVExportStatusResponse) {
+    CSVExportStatusResponse["queued"] = "queued";
+    CSVExportStatusResponse["in_progress"] = "in_progress";
+    CSVExportStatusResponse["ready"] = "ready";
+    CSVExportStatusResponse["failed"] = "failed";
+    CSVExportStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(CSVExportStatusResponse = exports.CSVExportStatusResponse || (exports.CSVExportStatusResponse = {}));
 var AuditEventType;
 (function (AuditEventType) {
     AuditEventType["historic_action"] = "historic_action";
@@ -413,26 +621,27 @@ var AuditEventType;
     AuditEventType["permit_granted_with_duration_challenge"] = "permit_granted_with_duration_challenge";
     AuditEventType["inspection_withdrawn"] = "inspection_withdrawn";
 })(AuditEventType = exports.AuditEventType || (exports.AuditEventType = {}));
-var AuditObjectType;
-(function (AuditObjectType) {
-    AuditObjectType["PERMIT"] = "permit";
-    AuditObjectType["REINSTATEMENT"] = "reinstatement";
-    AuditObjectType["INSPECTION"] = "inspection";
-    AuditObjectType["FPN"] = "fpn";
-    AuditObjectType["PAA"] = "paa";
-    AuditObjectType["WORKSTREAM"] = "workstream";
-    AuditObjectType["WORK"] = "work";
-    AuditObjectType["ORGANISATION"] = "organisation";
-    AuditObjectType["ACTIVITY"] = "activity";
-    AuditObjectType["FORWARD_PLAN"] = "forward_plan";
-    AuditObjectType["COMMENT"] = "comment";
-    AuditObjectType["SCHEDULED_INSPECTION"] = "scheduled_inspection";
-    AuditObjectType["SECTION_81"] = "section_81";
-    AuditObjectType["USER"] = "user";
-    AuditObjectType["GEOGRAPHICAL_AREA"] = "geographical_area";
-    AuditObjectType["CHANGE_REQUEST"] = "change_request";
-    AuditObjectType["APPLICATION"] = "application";
-})(AuditObjectType = exports.AuditObjectType || (exports.AuditObjectType = {}));
+var AuditObjectTypeResponse;
+(function (AuditObjectTypeResponse) {
+    AuditObjectTypeResponse["PERMIT"] = "permit";
+    AuditObjectTypeResponse["REINSTATEMENT"] = "reinstatement";
+    AuditObjectTypeResponse["INSPECTION"] = "inspection";
+    AuditObjectTypeResponse["FPN"] = "fpn";
+    AuditObjectTypeResponse["PAA"] = "paa";
+    AuditObjectTypeResponse["WORKSTREAM"] = "workstream";
+    AuditObjectTypeResponse["WORK"] = "work";
+    AuditObjectTypeResponse["ORGANISATION"] = "organisation";
+    AuditObjectTypeResponse["ACTIVITY"] = "activity";
+    AuditObjectTypeResponse["FORWARD_PLAN"] = "forward_plan";
+    AuditObjectTypeResponse["COMMENT"] = "comment";
+    AuditObjectTypeResponse["SCHEDULED_INSPECTION"] = "scheduled_inspection";
+    AuditObjectTypeResponse["SECTION_81"] = "section_81";
+    AuditObjectTypeResponse["USER"] = "user";
+    AuditObjectTypeResponse["GEOGRAPHICAL_AREA"] = "geographical_area";
+    AuditObjectTypeResponse["CHANGE_REQUEST"] = "change_request";
+    AuditObjectTypeResponse["APPLICATION"] = "application";
+    AuditObjectTypeResponse["upcoming_enum"] = "upcoming_enum";
+})(AuditObjectTypeResponse = exports.AuditObjectTypeResponse || (exports.AuditObjectTypeResponse = {}));
 var SampleInspectionSortColumn;
 (function (SampleInspectionSortColumn) {
     SampleInspectionSortColumn["inspection_expiry"] = "inspection_expiry";

--- a/dist/interfaces/reinstatementReportingResponse.d.ts
+++ b/dist/interfaces/reinstatementReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { ReinstatementStatus, ReinstatementType } from './referenceTypes';
+import { ReinstatementStatusResponse, ReinstatementTypeResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface ReinstatementReportingResponse extends ReportingResponse {
     rows: ReinstatementSummaryResponse[];
@@ -14,9 +14,9 @@ export interface ReinstatementSummaryResponse {
     location_description: string;
     registration_date: Date;
     reinstatement_date: Date;
-    reinstatement_type: ReinstatementType;
+    reinstatement_type: ReinstatementTypeResponse;
     reinstatement_type_string: string;
-    reinstatement_status: ReinstatementStatus;
+    reinstatement_status: ReinstatementStatusResponse;
     reinstatement_status_string: string;
     end_date: Date;
 }

--- a/dist/interfaces/sampleInspectionReportingResponse.d.ts
+++ b/dist/interfaces/sampleInspectionReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { InspectionCategory } from './referenceTypes';
+import { InspectionCategoryResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface SampleInspectionReportingResponse extends ReportingResponse {
     rows: SampleInspectionSummaryResponse[];
@@ -11,7 +11,7 @@ export interface SampleInspectionSummaryResponse {
     area?: string;
     location_description: string;
     promoter_organisation: string;
-    inspection_category: InspectionCategory;
+    inspection_category: InspectionCategoryResponse;
     inspection_category_string: string;
     expiry_date: Date;
 }

--- a/dist/interfaces/section81ReportingResponse.d.ts
+++ b/dist/interfaces/section81ReportingResponse.d.ts
@@ -1,4 +1,4 @@
-import { Section81Severity, Section81Status } from './referenceTypes';
+import { Section81SeverityResponse, Section81StatusResponse } from './referenceTypes';
 import { ReportingResponse } from './reportingResponse';
 export interface Section81ReportingResponse extends ReportingResponse {
     rows: Section81SummaryResponse[];
@@ -13,10 +13,10 @@ export interface Section81SummaryResponse {
     street: string;
     town?: string;
     area?: string;
-    section_81_severity: Section81Severity;
+    section_81_severity: Section81SeverityResponse;
     section_81_severity_string: string;
     made_safe_by_ha: boolean;
-    section_81_status: Section81Status;
+    section_81_status: Section81StatusResponse;
     section_81_status_string: string;
     status_changed_date: Date;
 }

--- a/dist/interfaces/usersResponse.d.ts
+++ b/dist/interfaces/usersResponse.d.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse';
-import { Role, WorkstreamAccessLevel } from './referenceTypes';
+import { RoleResponse, WorkstreamAccessLevelResponse } from './referenceTypes';
 export interface UsersReportingResponse extends ReportingResponse {
     rows: UsersSummaryResponse[];
 }
@@ -7,12 +7,12 @@ export interface UsersSummaryResponse {
     first_name?: string;
     last_name?: string;
     email: string;
-    roles?: Role[];
+    roles?: RoleResponse[];
     roles_string?: string[];
     workstreams?: UserWorkstreamAccess[];
 }
 export interface UserWorkstreamAccess {
     workstream_prefix: string;
-    access_level: WorkstreamAccessLevel;
+    access_level: WorkstreamAccessLevelResponse;
     access_level_string: string;
 }

--- a/dist/interfaces/workUpdateResponse.d.ts
+++ b/dist/interfaces/workUpdateResponse.d.ts
@@ -1,10 +1,10 @@
-import { AuditEventType, AuditObjectType } from './referenceTypes';
+import { AuditEventType, AuditObjectTypeResponse } from './referenceTypes';
 export interface WorkUpdateResponse {
     work_reference_number: string;
     update_date_time: Date;
     update_id: number;
     event_type: AuditEventType;
     event_type_string: string;
-    object_type: AuditObjectType;
+    object_type: AuditObjectTypeResponse;
     object_type_string: string;
 }

--- a/dist/interfaces/workstreamReportingResponse.d.ts
+++ b/dist/interfaces/workstreamReportingResponse.d.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse';
-import { WorkstreamStatus } from './referenceTypes';
+import { WorkstreamStatusResponse } from './referenceTypes';
 export interface WorkstreamReportingResponse extends ReportingResponse {
     rows: WorkstreamSummaryResponse[];
 }
@@ -7,7 +7,7 @@ export interface WorkstreamSummaryResponse {
     prefix: string;
     name: string;
     description?: string;
-    status: WorkstreamStatus;
+    status: WorkstreamStatusResponse;
     status_string: string;
     swa_code: string;
 }

--- a/src/interfaces/alterationReportingResponse.ts
+++ b/src/interfaces/alterationReportingResponse.ts
@@ -1,4 +1,4 @@
-import { AlterationStatus, WorkCategory, WorkStatus, AlterationType, LaneRentalAssessmentOutcome } from './referenceTypes'
+import { AlterationStatusResponse, AlterationTypeResponse, LaneRentalAssessmentOutcomeResponse, WorkCategoryResponse, WorkStatusResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface AlterationReportingResponse extends ReportingResponse {
@@ -15,22 +15,22 @@ export interface AlterationSummaryResponse {
   location_description: string
   highway_authority: string
   promoter: string
-  work_status: WorkStatus
+  work_status: WorkStatusResponse
   work_status_string: string
   proposed_start_date: Date
   proposed_end_date: Date
   proposed_start_time?: Date
   proposed_end_time?: Date
-  work_category: WorkCategory
+  work_category: WorkCategoryResponse
   work_category_string: string
-  alteration_status: AlterationStatus
+  alteration_status: AlterationStatusResponse
   alteration_status_string: string
-  alteration_type: AlterationType
+  alteration_type: AlterationTypeResponse
   alteration_type_string: string
   date_created: Date
   deadline_date: Date
   status_changed_date: Date
-  lane_rental_assessment_outcome?: LaneRentalAssessmentOutcome
+  lane_rental_assessment_outcome?: LaneRentalAssessmentOutcomeResponse
   lane_rental_assessment_outcome_string?: string
   lane_rental_charges_not_agreed: boolean
   lane_rental_charges_potentially_apply: boolean

--- a/src/interfaces/commentReportingResponse.ts
+++ b/src/interfaces/commentReportingResponse.ts
@@ -1,4 +1,4 @@
-import { CommentTopic } from './referenceTypes'
+import { CommentTopicResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface CommentReportingResponse extends ReportingResponse {
@@ -7,7 +7,7 @@ export interface CommentReportingResponse extends ReportingResponse {
 
 export interface CommentSummaryResponse {
   work_reference_number: string
-  topic: CommentTopic
+  topic: CommentTopicResponse
   topic_string: string
   author_email_address: string
   author_organisation_reference: string

--- a/src/interfaces/csvExportReportingResponse.ts
+++ b/src/interfaces/csvExportReportingResponse.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse'
-import { CSVExportStatus } from './referenceTypes'
+import { CSVExportStatusResponse } from './referenceTypes'
 
 export interface CSVExportReportingResponse extends ReportingResponse {
   rows: CSVExportSummaryResponse[]
@@ -9,7 +9,7 @@ export interface CSVExportSummaryResponse {
   csv_export_id: number
   filename: string
   date_created: Date
-  csv_export_status: CSVExportStatus
+  csv_export_status: CSVExportStatusResponse
   csv_export_status_string: string
   username: string
 }

--- a/src/interfaces/forwardPlanReportingResponse.ts
+++ b/src/interfaces/forwardPlanReportingResponse.ts
@@ -1,4 +1,4 @@
-import { ForwardPlanStatus } from './referenceTypes'
+import { ForwardPlanStatusResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface ForwardPlanReportingResponse extends ReportingResponse {
@@ -16,7 +16,7 @@ export interface ForwardPlanSummaryResponse {
   area: string
   proposed_start_date: Date
   proposed_end_date: Date
-  forward_plan_status: ForwardPlanStatus
+  forward_plan_status: ForwardPlanStatusResponse
   forward_plan_status_string: string
   date_created: Date
 }

--- a/src/interfaces/fpnReportingResponse.ts
+++ b/src/interfaces/fpnReportingResponse.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse'
-import { FPNStatus, OffenceCode } from './referenceTypes'
+import { FPNStatusResponse, OffenceCodeResponse } from './referenceTypes'
 
 export interface FPNReportingResponse extends ReportingResponse {
   rows: FPNSummaryResponse[]
@@ -10,11 +10,11 @@ export interface FPNSummaryResponse {
   work_reference_number: string
   promoter: string
   highway_authority: string
-  offence_code: OffenceCode
+  offence_code: OffenceCodeResponse
   offence_code_string: string
   street_name: string
   issue_date: Date
-  status: FPNStatus
+  status: FPNStatusResponse
   status_string: string
   status_changed_date: Date
 }

--- a/src/interfaces/inspectionReportingResponse.ts
+++ b/src/interfaces/inspectionReportingResponse.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse'
-import { InspectionResponseType, InspectionType, InspectionCategory, InspectionOutcome, InspectionStatusResponse } from './referenceTypes'
+import { InspectionCategoryResponse, InspectionOutcomeResponse, InspectionResponseTypeResponse, InspectionTypeResponse, InspectionStatusResponse } from './referenceTypes'
 
 export interface InspectionReportingResponse extends ReportingResponse {
   rows: InspectionSummaryResponse[]
@@ -7,7 +7,7 @@ export interface InspectionReportingResponse extends ReportingResponse {
 
 export interface InspectionSummaryResponse {
   inspection_date: Date
-  inspection_response_type: InspectionResponseType
+  inspection_response_type: InspectionResponseTypeResponse
   inspection_response_type_string: string
   work_reference_number: string
   location_description: string
@@ -15,11 +15,11 @@ export interface InspectionSummaryResponse {
   town: string
   area: string
   inspection_reference_number?: string
-  inspection_type: InspectionType
+  inspection_type: InspectionTypeResponse
   inspection_type_string: string
-  inspection_category?: InspectionCategory
+  inspection_category?: InspectionCategoryResponse
   inspection_category_string?: string
-  inspection_outcome?: InspectionOutcome
+  inspection_outcome?: InspectionOutcomeResponse
   inspection_outcome_string?: string
   reinspection_date_time?: Date
   highway_authority: string

--- a/src/interfaces/permitCondition.ts
+++ b/src/interfaces/permitCondition.ts
@@ -1,7 +1,7 @@
-import { PermitConditionType } from './referenceTypes'
+import { PermitConditionTypeResponse } from './referenceTypes'
 
 export interface PermitCondition {
-  condition: PermitConditionType,
+  condition: PermitConditionTypeResponse,
   condition_string: string,
   comment?: string
 }

--- a/src/interfaces/permitReportingResponse.ts
+++ b/src/interfaces/permitReportingResponse.ts
@@ -1,4 +1,4 @@
-import { PermitStatus, WorkCategory, TrafficManagementType, WorkStatus, LaneRentalAssessmentOutcome, AssessmentStatus } from './referenceTypes'
+import { WorkCategoryResponse, TrafficManagementTypeResponse, AssessmentStatusResponse, PermitStatusResponse, WorkStatusResponse, LaneRentalAssessmentOutcomeResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 import { PermitCondition } from './permitCondition'
 
@@ -17,12 +17,12 @@ export interface PermitSummaryResponse {
   street: string
   town: string
   area: string
-  work_category: WorkCategory
+  work_category: WorkCategoryResponse
   work_category_string: string
   description_of_work: string
-  traffic_management_type: TrafficManagementType
+  traffic_management_type: TrafficManagementTypeResponse
   traffic_management_type_string: string
-  assessment_status?: AssessmentStatus
+  assessment_status?: AssessmentStatusResponse
   assessment_status_string?: string
   proposed_start_date: Date
   proposed_end_date: Date
@@ -30,9 +30,9 @@ export interface PermitSummaryResponse {
   proposed_end_time?: Date
   actual_start_date?: Date
   actual_end_date?: Date
-  status: PermitStatus
+  status: PermitStatusResponse
   status_string: string
-  work_status: WorkStatus
+  work_status: WorkStatusResponse
   work_status_string: string
   deadline_date: Date
   date_created: Date
@@ -48,7 +48,7 @@ export interface PermitSummaryResponse {
   is_early_start: boolean
   is_high_impact_traffic_management: boolean
   is_lane_rental: boolean
-  lane_rental_assessment_outcome?: LaneRentalAssessmentOutcome
+  lane_rental_assessment_outcome?: LaneRentalAssessmentOutcomeResponse
   lane_rental_assessment_outcome_string?: string
   lane_rental_charges_not_agreed: boolean
   lane_rental_charges_potentially_apply: boolean

--- a/src/interfaces/referenceTypes.ts
+++ b/src/interfaces/referenceTypes.ts
@@ -9,6 +9,18 @@ export enum PermitStatus {
   progressed = 'progressed'
 }
 
+export enum PermitStatusResponse {
+  submitted = 'submitted',
+  granted = 'granted',
+  permit_modification_request = 'permit_modification_request',
+  refused = 'refused',
+  closed = 'closed',
+  cancelled = 'cancelled',
+  revoked = 'revoked',
+  progressed = 'progressed',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum AssessmentStatus {
   granted = 'granted',
   granted_auto = 'granted_auto',
@@ -18,9 +30,25 @@ export enum AssessmentStatus {
   revoked = 'revoked'
 }
 
+export enum AssessmentStatusResponse {
+  granted = 'granted',
+  granted_auto = 'granted_auto',
+  refused = 'refused',
+  refused_auto = 'refused_auto',
+  permit_modification_request = 'permit_modification_request',
+  revoked = 'revoked',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum ReinstatementStatus {
   interim = 'interim',
   permanent = 'permanent'
+}
+
+export enum ReinstatementStatusResponse {
+  interim = 'interim',
+  permanent = 'permanent',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum FPNStatus {
@@ -32,9 +60,25 @@ export enum FPNStatus {
   withdrawn = 'withdrawn'
 }
 
+export enum FPNStatusResponse {
+  issued = 'issued',
+  accepted = 'accepted',
+  paid = 'paid',
+  paid_discounted = 'paid_discounted',
+  disputed = 'disputed',
+  withdrawn = 'withdrawn',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum WorkstreamStatus {
   active = 'active',
   deactivated = 'deactivated'
+}
+
+export enum WorkstreamStatusResponse {
+  active = 'active',
+  deactivated = 'deactivated',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum OffenceCode {
@@ -42,6 +86,14 @@ export enum OffenceCode {
   offence_code_06 = 'offence_code_06',
   offence_code_08 = 'offence_code_08',
   offence_code_09 = 'offence_code_09'
+}
+
+export enum OffenceCodeResponse {
+  offence_code_05 = 'offence_code_05',
+  offence_code_06 = 'offence_code_06',
+  offence_code_08 = 'offence_code_08',
+  offence_code_09 = 'offence_code_09',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum CommentTopic {
@@ -55,6 +107,20 @@ export enum CommentTopic {
   IMPOSED_VARIATION = 'IMPOSED_VARIATION',
   DURATION_CHALLENGE = 'DURATION_CHALLENGE',
   SECTION_81 = 'SECTION_81'
+}
+
+export enum CommentTopicResponse {
+  GENERAL = 'GENERAL',
+  SECTION_74 = 'SECTION_74',
+  INSPECTION = 'INSPECTION',
+  FPN = 'FPN',
+  OVERRUN = 'OVERRUN',
+  FORWARD_PLAN = 'FORWARD_PLAN',
+  CHANGE_REQUEST = 'CHANGE_REQUEST',
+  IMPOSED_VARIATION = 'IMPOSED_VARIATION',
+  DURATION_CHALLENGE = 'DURATION_CHALLENGE',
+  SECTION_81 = 'SECTION_81',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum SortDirection {
@@ -94,9 +160,23 @@ export enum InspectionType {
   section_81 = 'section_81'
 }
 
+export enum InspectionTypeResponse {
+  live_site = 'live_site',
+  reinstatement = 'reinstatement',
+  non_compliance_follow_up = 'non_compliance_follow_up',
+  section_81 = 'section_81',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum InspectionResponseType {
   inspection = 'inspection',
   reinspection = 'reinspection'
+}
+
+export enum InspectionResponseTypeResponse {
+  inspection = 'inspection',
+  reinspection = 'reinspection',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum InspectionCategory {
@@ -110,6 +190,20 @@ export enum InspectionCategory {
   follow_up_completion = 'follow_up_completion',
   site_occupancy = 'site_occupancy',
   conditions = 'conditions'
+}
+
+export enum InspectionCategoryResponse {
+  a = 'a',
+  b = 'b',
+  c = 'c',
+  third_party = 'third_party',
+  routine = 'routine',
+  joint_site_visit = 'joint_site_visit',
+  follow_up = 'follow_up',
+  follow_up_completion = 'follow_up_completion',
+  site_occupancy = 'site_occupancy',
+  conditions = 'conditions',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum InspectionOutcome {
@@ -126,6 +220,21 @@ export enum InspectionOutcome {
   works_stopped = 'works_stopped'
 }
 
+export enum InspectionOutcomeResponse {
+  passed = 'passed',
+  unable_to_complete_inspection = 'unable_to_complete_inspection',
+  failed_low = 'failed_low',
+  failed_high = 'failed_high',
+  further_inspections_required = 'further_inspections_required',
+  agreed_site_compliance = 'agreed_site_compliance',
+  non_compliant_with_conditions = 'non_compliant_with_conditions',
+  works_stopped_apparatus_remaining = 'works_stopped_apparatus_remaining',
+  works_in_progress_no_carriageway_incursion = 'works_in_progress_no_carriageway_incursion',
+  works_in_progress = 'works_in_progress',
+  works_stopped = 'works_stopped',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum InspectionSortColumn {
   inspection_date = 'inspection_date'
 }
@@ -138,6 +247,17 @@ export enum WorkCategory {
   immediate_emergency = 'immediate_emergency',
   paa = 'paa',
   hs2_highway = 'hs2_highway'
+}
+
+export enum WorkCategoryResponse {
+  minor = 'minor',
+  standard = 'standard',
+  major = 'major',
+  immediate_urgent = 'immediate_urgent',
+  immediate_emergency = 'immediate_emergency',
+  paa = 'paa',
+  hs2_highway = 'hs2_highway',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum TrafficManagementType {
@@ -154,6 +274,21 @@ export enum TrafficManagementType {
   no_carriageway_incursion = 'no_carriageway_incursion'
 }
 
+export enum TrafficManagementTypeResponse {
+  road_closure = 'road_closure',
+  contra_flow = 'contra_flow',
+  lane_closure = 'lane_closure',
+  multi_way_signals = 'multi_way_signals',
+  two_way_signals = 'two_way_signals',
+  convoy_workings = 'convoy_workings',
+  stop_go_boards = 'stop_go_boards',
+  priority_working = 'priority_working',
+  give_and_take = 'give_and_take',
+  some_carriageway_incursion = 'some_carriageway_incursion',
+  no_carriageway_incursion = 'no_carriageway_incursion',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum AlterationStatus {
   submitted = 'submitted',
   granted = 'granted',
@@ -163,6 +298,18 @@ export enum AlterationStatus {
   cancelled = 'cancelled',
   revoked = 'revoked',
   auto_applied = 'auto_applied'
+}
+
+export enum AlterationStatusResponse {
+  submitted = 'submitted',
+  granted = 'granted',
+  granted_with_duration_challenge = 'granted_with_duration_challenge',
+  refused = 'refused',
+  deemed = 'deemed',
+  cancelled = 'cancelled',
+  revoked = 'revoked',
+  auto_applied = 'auto_applied',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum AlterationSortColumn {
@@ -182,6 +329,17 @@ export enum AlterationType {
   MODIFIED_PERMIT = 'MODIFIED_PERMIT'
 }
 
+export enum AlterationTypeResponse {
+  PROMOTER_IMPOSED_CHANGE = 'PROMOTER_IMPOSED_CHANGE',
+  PROMOTER_CHANGE_REQUEST = 'PROMOTER_CHANGE_REQUEST',
+  HA_CHANGE_REQUEST = 'HA_CHANGE_REQUEST',
+  HA_IMPOSED_CHANGE = 'HA_IMPOSED_CHANGE',
+  WORK_EXTENSION = 'WORK_EXTENSION',
+  DURATION_CHALLENGE = 'DURATION_CHALLENGE',
+  MODIFIED_PERMIT = 'MODIFIED_PERMIT',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum WorkStatus {
   planned = 'planned',
   in_progress = 'in_progress',
@@ -193,10 +351,29 @@ export enum WorkStatus {
   section_81 = 'section_81'
 }
 
+export enum WorkStatusResponse {
+  planned = 'planned',
+  in_progress = 'in_progress',
+  completed = 'completed',
+  cancelled = 'cancelled',
+  unattributable = 'unattributable',
+  historical = 'historical',
+  non_notifiable = 'non_notifiable',
+  section_81 = 'section_81',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum ForwardPlanStatus {
   raised = 'raised',
   cancelled = 'cancelled',
   progressed = 'progressed'
+}
+
+export enum ForwardPlanStatusResponse {
+  raised = 'raised',
+  cancelled = 'cancelled',
+  progressed = 'progressed',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum ForwardPlanSortColumn {
@@ -204,7 +381,7 @@ export enum ForwardPlanSortColumn {
   end_date = 'end_date'
 }
 
-export enum PermitConditionType {
+export enum PermitConditionTypeResponse {
   NCT01a = 'NCT01a',
   NCT01b = 'NCT01b',
   NCT02a = 'NCT02a',
@@ -222,7 +399,8 @@ export enum PermitConditionType {
   NCT10a = 'NCT10a',
   NCT11a = 'NCT11a',
   NCT11b = 'NCT11b',
-  NCT12a = 'NCT12a'
+  NCT12a = 'NCT12a',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum LaneRentalAssessmentOutcome {
@@ -233,11 +411,21 @@ export enum LaneRentalAssessmentOutcome {
   charges_not_applicable = 'charges_not_applicable'
 }
 
-export enum ReinstatementType {
+export enum LaneRentalAssessmentOutcomeResponse {
+  chargeable = 'chargeable',
+  potentially_chargeable = 'potentially_chargeable',
+  charges_waived = 'charges_waived',
+  exempt = 'exempt',
+  charges_not_applicable = 'charges_not_applicable',
+  upcoming_enum = 'upcoming_enum'
+}
+
+export enum ReinstatementTypeResponse {
   excavation = 'excavation',
   bar_holes = 'bar_holes',
   core_holes = 'core_holes',
-  pole_testing = 'pole_testing'
+  pole_testing = 'pole_testing',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum AdditionalSpecialDesignationCode {
@@ -272,6 +460,12 @@ export enum Section81Severity {
   low = 'low'
 }
 
+export enum Section81SeverityResponse {
+  high = 'high',
+  low = 'low',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum Section81Status {
   issued = 'issued',
   acknowledged = 'acknowledged',
@@ -282,30 +476,44 @@ export enum Section81Status {
   cancelled = 'cancelled'
 }
 
+export enum Section81StatusResponse {
+  issued = 'issued',
+  acknowledged = 'acknowledged',
+  accepted = 'accepted',
+  accepted_fixed = 'accepted_fixed',
+  rejected = 'rejected',
+  resolved_by_ha = 'resolved_by_ha',
+  cancelled = 'cancelled',
+  upcoming_enum = 'upcoming_enum'
+}
+
 export enum Section81SortColumn {
   status_changed_date = 'status_changed_date'
 }
 
-export enum Role {
+export enum RoleResponse {
   Planner = 'Planner',
   HighwayAuthority = 'HighwayAuthority',
   Admin = 'Admin',
   Contractor = 'Contractor',
   API = 'API',
   UI = 'UI',
-  DataExport = 'DataExport'
+  DataExport = 'DataExport',
+  upcoming_enum = 'upcoming_enum'
 }
 
-export enum WorkstreamAccessLevel {
+export enum WorkstreamAccessLevelResponse {
   read_only = 'read_only',
-  full_write = 'full_write'
+  full_write = 'full_write',
+  upcoming_enum = 'upcoming_enum'
 }
 
-export enum CSVExportStatus {
+export enum CSVExportStatusResponse {
   queued = 'queued',
   in_progress = 'in_progress',
   ready = 'ready',
-  failed = 'failed'
+  failed = 'failed',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum AuditEventType {
@@ -411,7 +619,7 @@ export enum AuditEventType {
   inspection_withdrawn = 'inspection_withdrawn'
 }
 
-export enum AuditObjectType {
+export enum AuditObjectTypeResponse {
   PERMIT = 'permit',
   REINSTATEMENT = 'reinstatement',
   INSPECTION = 'inspection',
@@ -428,7 +636,8 @@ export enum AuditObjectType {
   USER = 'user',
   GEOGRAPHICAL_AREA = 'geographical_area',
   CHANGE_REQUEST = 'change_request',
-  APPLICATION = 'application'
+  APPLICATION = 'application',
+  upcoming_enum = 'upcoming_enum'
 }
 
 export enum SampleInspectionSortColumn {

--- a/src/interfaces/reinstatementReportingResponse.ts
+++ b/src/interfaces/reinstatementReportingResponse.ts
@@ -1,4 +1,4 @@
-import { ReinstatementStatus, ReinstatementType } from './referenceTypes'
+import { ReinstatementStatusResponse, ReinstatementTypeResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface ReinstatementReportingResponse extends ReportingResponse {
@@ -16,9 +16,9 @@ export interface ReinstatementSummaryResponse {
   location_description: string
   registration_date: Date
   reinstatement_date: Date
-  reinstatement_type: ReinstatementType
+  reinstatement_type: ReinstatementTypeResponse
   reinstatement_type_string: string
-  reinstatement_status: ReinstatementStatus
+  reinstatement_status: ReinstatementStatusResponse
   reinstatement_status_string: string
   end_date: Date
 }

--- a/src/interfaces/sampleInspectionReportingResponse.ts
+++ b/src/interfaces/sampleInspectionReportingResponse.ts
@@ -1,4 +1,4 @@
-import { InspectionCategory } from './referenceTypes'
+import { InspectionCategoryResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface SampleInspectionReportingResponse extends ReportingResponse {
@@ -13,7 +13,7 @@ export interface SampleInspectionSummaryResponse {
   area?: string
   location_description: string
   promoter_organisation: string
-  inspection_category: InspectionCategory
+  inspection_category: InspectionCategoryResponse
   inspection_category_string: string
   expiry_date: Date
 }

--- a/src/interfaces/section81ReportingResponse.ts
+++ b/src/interfaces/section81ReportingResponse.ts
@@ -1,4 +1,4 @@
-import { Section81Severity, Section81Status } from './referenceTypes'
+import { Section81SeverityResponse, Section81StatusResponse } from './referenceTypes'
 import { ReportingResponse } from './reportingResponse'
 
 export interface Section81ReportingResponse extends ReportingResponse {
@@ -15,10 +15,10 @@ export interface Section81SummaryResponse {
   street: string
   town?: string
   area?: string
-  section_81_severity: Section81Severity
+  section_81_severity: Section81SeverityResponse
   section_81_severity_string: string
   made_safe_by_ha: boolean
-  section_81_status: Section81Status
+  section_81_status: Section81StatusResponse
   section_81_status_string: string
   status_changed_date: Date
 }

--- a/src/interfaces/usersResponse.ts
+++ b/src/interfaces/usersResponse.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse'
-import { Role, WorkstreamAccessLevel } from './referenceTypes'
+import { RoleResponse, WorkstreamAccessLevelResponse } from './referenceTypes'
 
 export interface UsersReportingResponse extends ReportingResponse {
   rows: UsersSummaryResponse[]
@@ -9,13 +9,13 @@ export interface UsersSummaryResponse {
   first_name?: string
   last_name?: string
   email: string
-  roles?: Role[]
+  roles?: RoleResponse[]
   roles_string?: string[]
   workstreams?: UserWorkstreamAccess[]
 }
 
 export interface UserWorkstreamAccess {
   workstream_prefix: string
-  access_level: WorkstreamAccessLevel
+  access_level: WorkstreamAccessLevelResponse
   access_level_string: string
 }

--- a/src/interfaces/workUpdateResponse.ts
+++ b/src/interfaces/workUpdateResponse.ts
@@ -1,4 +1,4 @@
-import { AuditEventType, AuditObjectType } from './referenceTypes'
+import { AuditEventType, AuditObjectTypeResponse } from './referenceTypes'
 
 export interface WorkUpdateResponse {
   work_reference_number: string
@@ -6,6 +6,6 @@ export interface WorkUpdateResponse {
   update_id: number,
   event_type: AuditEventType,
   event_type_string: string,
-  object_type: AuditObjectType
+  object_type: AuditObjectTypeResponse
   object_type_string: string
 }

--- a/src/interfaces/workstreamReportingResponse.ts
+++ b/src/interfaces/workstreamReportingResponse.ts
@@ -1,5 +1,5 @@
 import { ReportingResponse } from './reportingResponse'
-import { WorkstreamStatus } from './referenceTypes'
+import { WorkstreamStatusResponse } from './referenceTypes'
 
 export interface WorkstreamReportingResponse extends ReportingResponse {
   rows: WorkstreamSummaryResponse[]
@@ -9,7 +9,7 @@ export interface WorkstreamSummaryResponse {
   prefix: string
   name: string
   description?: string
-  status: WorkstreamStatus
+  status: WorkstreamStatusResponse
   status_string: string
   swa_code: string
 }


### PR DESCRIPTION
## Description

split request and response enum definitions so that upcoming enum can be added to the response

Reporting API: https://github.com/departmentfortransport/street-manager-reporting-api/pull/347
Reporting Client: https://github.com/departmentfortransport/street-manager-reporting-client/pull/129

Frontend: https://github.com/departmentfortransport/street-manager-frontend/pull/1576

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
